### PR TITLE
Added ModMenu Compat

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,7 @@ dependencies {
     modImplementation(libs.rconfigkt)
     modImplementation(libs.rlib)
     modImplementation(libs.olympus)
+    modImplementation(libs.modmenu)
 
     include(libs.hypixelapi)
     include(libs.skyblockapi)
@@ -80,7 +81,7 @@ dependencies {
     include(libs.olympus)
 
     modRuntimeOnly(libs.devauth)
-    modRuntimeOnly(libs.modmenu)
+
 }
 
 tasks.processResources {

--- a/src/client/kotlin/tech/thatgravyboat/skycubed/config/ConfigManager.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skycubed/config/ConfigManager.kt
@@ -3,6 +3,7 @@ package tech.thatgravyboat.skycubed.config
 import com.teamresourceful.resourcefulconfig.api.client.ResourcefulConfigScreen
 import com.teamresourceful.resourcefulconfig.api.loader.Configurator
 import net.fabricmc.loader.api.FabricLoader
+import net.minecraft.client.gui.screens.Screen
 import tech.thatgravyboat.skyblockapi.api.events.base.Subscription
 import tech.thatgravyboat.skyblockapi.api.events.misc.RegisterCommandsEvent
 import tech.thatgravyboat.skyblockapi.helpers.McClient
@@ -21,10 +22,12 @@ object ConfigManager {
     fun onRegisterCommands(event: RegisterCommandsEvent) {
         event.register("skycubed") {
             callback {
-                McClient.setScreen(ResourcefulConfigScreen.get(null, configurator, Config::class.java))
+                McClient.setScreen(getScreen(null))
             }
         }
     }
+
+    fun getScreen(parent: Screen?) = ResourcefulConfigScreen.get(parent, configurator, Config::class.java)
 
     fun save() {
         configurator.saveConfig(Config::class.java)

--- a/src/client/kotlin/tech/thatgravyboat/skycubed/config/ModMenuCompat.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skycubed/config/ModMenuCompat.kt
@@ -1,0 +1,11 @@
+package tech.thatgravyboat.skycubed.config
+
+import com.terraformersmc.modmenu.api.ConfigScreenFactory
+import com.terraformersmc.modmenu.api.ModMenuApi
+import net.minecraft.client.gui.screens.Screen
+
+object ModMenuCompat: ModMenuApi {
+    override fun getModConfigScreenFactory(): ConfigScreenFactory<Screen> {
+        return ConfigScreenFactory { ConfigManager.getScreen(it) }
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,6 +22,12 @@
                 "adapter": "kotlin",
                 "value": "tech.thatgravyboat.skycubed.SkyCubed"
             }
+        ],
+        "modmenu": [
+            {
+                "adapter": "kotlin",
+                "value": "tech.thatgravyboat.skycubed.config.ModMenuCompat"
+            }
         ]
     },
     "mixins": [


### PR DESCRIPTION
Added ModMenu config screen compat. As a result of this, I also moved ModMenu from `modRuntimeOnly` to `modImplementation` and added a helper function for generating config screens, since that is now done in multiple places.