### PR TITLE
fix: dialogue overlay not working with certain npcs

### DIFF
--- a/src/client/kotlin/tech/thatgravyboat/skycubed/features/overlays/DialogueOverlay.kt
+++ b/src/client/kotlin/tech/thatgravyboat/skycubed/features/overlays/DialogueOverlay.kt
@@ -43,7 +43,7 @@ import kotlin.math.max
 @RegisterOverlay
 object DialogueOverlay : Overlay {
 
-    private val regex = ComponentRegex("\\[NPC] (?<name>[\\w.\\s]+): (?<message>.+)")
+    private val regex = ComponentRegex("\\[NPC] (?<name>[^:]+): (?<message>.+)")
     private val yesNoRegex = listOf(
         ComponentRegex("Select an option: (?<yes>\\[YES]) (?<no>\\[NO]) "),
         ComponentRegex("\\nAccept the trapper's task to hunt the animal\\?\\nClick an option: (?<yes>\\[YES]) - (?<no>\\[NO])"),


### PR DESCRIPTION
npcs are melody in alpha (and i think Ävaeìkx in rift too)