### PR TITLE
feat: add Mines Slayer commission

### DIFF
--- a/src/client/resources/repo/commissions.json
+++ b/src/client/resources/repo/commissions.json
@@ -50,6 +50,10 @@
             "max": 10
         },
 
+        "Mines Slayer": {
+            "type": "decimal",
+            "max": 50
+        },
         "Goblin Slayer": {
             "type": "decimal",
             "max": 100


### PR DESCRIPTION
This is a tutorial commission that replaces the player's first "Slayer" commission, not listed on the official wiki for some reason.