### PR TITLE
fix: NPE in DialogueEntities when level = null

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ kotlin-symbol-processor = "2.2.20-2.0.2"
 
 resourceful-config-kotlin = "3.5.15"
 
-skyblockapi = "4.1.3"
+skyblockapi = "4.0.8"
 
 meowdding-lib = "4.0.1"
 meowdding-auto-mixins = "1.0.3"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ kotlin-symbol-processor = "2.2.20-2.0.2"
 
 resourceful-config-kotlin = "3.5.15"
 
-skyblockapi = "4.0.8"
+skyblockapi = "4.1.3"
 
 meowdding-lib = "4.0.1"
 meowdding-auto-mixins = "1.0.3"

--- a/src/main/kotlin/tech/thatgravyboat/skycubed/features/overlays/dialogue/DialogueEntities.kt
+++ b/src/main/kotlin/tech/thatgravyboat/skycubed/features/overlays/dialogue/DialogueEntities.kt
@@ -52,12 +52,13 @@ object DialogueEntities {
 
     @OptIn(ExperimentalEncodingApi::class)
     fun get(name: String, npc: DialogueNpc): LivingEntity? {
-        val entity = lastClickedEntities.keys.find { npc -> McLevel.self.getEntitiesOfClass(ArmorStand::class.java, npc.boundingBox).any { it.customName?.stripped == name } }
+        val level = McLevel.selfOrNull ?: return null
+        val entity = lastClickedEntities.keys.find { npc -> level.getEntitiesOfClass(ArmorStand::class.java, npc.boundingBox).any { it.customName?.stripped == name } }
         if (entity != null && entity.isAlive) {
             lastClickedEntities[entity] = System.currentTimeMillis()
             return entity
         }
-        val customEntity = EntityType.byString(npc.type).getOrNull()?.runCatching { this.create(McLevel.self, EntitySpawnReason.EVENT) }?.getOrNull()
+        val customEntity = EntityType.byString(npc.type).getOrNull()?.runCatching { this.create(level, EntitySpawnReason.EVENT) }?.getOrNull()
         if (customEntity is LivingEntity) {
             return customEntity
         }


### PR DESCRIPTION
bump + should fix NullPointerExceptions in `McLevel.getLevel()` when  SkyCubed tried to access it to render dialogue entities on world switch with the changes of commit `7e9fa47`/ PR #355