### PR TITLE
fix(spinningItemRenderer): render correctly in 26.1

### DIFF
--- a/src/main/kotlin/tech/thatgravyboat/skycubed/utils/SpinningItemRenderer.kt
+++ b/src/main/kotlin/tech/thatgravyboat/skycubed/utils/SpinningItemRenderer.kt
@@ -49,6 +49,8 @@ class SpinningItemRenderer() : PictureInPictureRenderer<SpinningItemRenderState>
             val submitNodeCollector = featureRenderer.submitNodeStorage
             *///? }
             item.submit(stack, submitNodeCollector, 15728880, OverlayTexture.NO_OVERLAY, 0)
+            //? 26.1
+            //featureRenderer.renderAllFeatures()
         }
     }
 


### PR DESCRIPTION
closes #115 

idk why it renders in such a weird way when you dont run `renderAllFeatures()` but yeah